### PR TITLE
Remove inactive user mdelder so new PRs can auto assign to a more frequent community participant

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,11 @@
 approvers:
 - deads2k
-- pmorie
-- mdelder
 - qiujian16
+
+emeritus_approvers:
+- mdelder # 2022-07-14
+- pmorie # 2022-07-14
 
 reviewers:
 - deads2k
-- pmorie
 - qiujian16
-- mdelder


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

I want to thank @mdelder once again for all his work on the Open Cluster Management project. Needless to say, we wouldn't be here today without Michael's innovation and hard work. Based on community's feedback, it seems like the new PRs are auto assigned to Michael quite frequently and he has not been a frequent participant. So this PR is just to remove Michael from the OWNERs file, so the new PRs will be auto assigned to a more active community participant. Michael is ALWAYS welcome in the OCM community and we hope to work with him and rely on his technical prowess once again. 