### PR TITLE
rename detached mode to hosted mode

### DIFF
--- a/enhancements/sig-architecture/33-hosted-deploy-mode/metadata.yaml
+++ b/enhancements/sig-architecture/33-hosted-deploy-mode/metadata.yaml
@@ -1,4 +1,4 @@
-title: detached-mode
+title: hosted-mode
 authors:
   - "@xuezhaojun"
   - "@zhujian7"
@@ -11,5 +11,5 @@ approvers:
   - "@zhiweiyin318"
   - "@elgnay"
 creation-date: 2021-11-16
-last-updated: 2022-02-09
-status: provisional
+last-updated: 2022-06-20
+status: implemented


### PR DESCRIPTION
Signed-off-by: zhujian <jiazhu@redhat.com>

- rename detached mode to hosted mode
- rename management cluster to hosting cluster
- update the status to implemented
- change file name from `detached-deploy-mode.md` to `README.md`