### PR TITLE
Update OperatorPolicy design

### DIFF
--- a/enhancements/sig-policy/89-operator-policy-kind/metadata.yaml
+++ b/enhancements/sig-policy/89-operator-policy-kind/metadata.yaml
@@ -10,5 +10,5 @@ reviewers:
 approvers:
   - TBD
 creation-date: "2023-03-06"
-last-updated: "2023-07-27"
+last-updated: "2024-04-09"
 status: implementable


### PR DESCRIPTION
The main change is that we no longer intend to use finalizers to prune objects when the policy is deleted - instead, the user can use the "mustnothave" mode, which allows for more control and better status reporting.

This also updates the status examples to match what is currently implemented.