### PR TITLE
Update the progressive policy rollout design

### DIFF
--- a/enhancements/sig-policy/99-policy-placement-strategy/metadata.yaml
+++ b/enhancements/sig-policy/99-policy-placement-strategy/metadata.yaml
@@ -1,6 +1,7 @@
 title: policy-placement-strategy
 authors:
   - "@dhaiducek"
+  - "@mprahl"
 reviewers:
   - "@mprahl"
   - "@gparvin"


### PR DESCRIPTION
Note that since there's so much change, it's best to treat this like a new document when reviewing the changes (e.g. look at the markdown file directly instead of the diff).

Part of the proposal applies to all of Open Cluster Management.