### PR TITLE
Update OperatorPolicy design

### DIFF
--- a/enhancements/sig-policy/89-operator-policy-kind/metadata.yaml
+++ b/enhancements/sig-policy/89-operator-policy-kind/metadata.yaml
@@ -10,5 +10,5 @@ reviewers:
 approvers:
   - TBD
 creation-date: "2023-03-06"
-last-updated: "2024-04-09"
+last-updated: "2024-05-28"
 status: implementable


### PR DESCRIPTION
Rename `statusConfig` to `complianceConfig`, and use options `Compliant` and `NonCompliant`, which might be more clear to users.