### PR TITLE
Fix error in the documentation

### DIFF
--- a/enhancements/sig-policy/89-operator-policy-kind/README.md
+++ b/enhancements/sig-policy/89-operator-policy-kind/README.md
@@ -98,7 +98,7 @@ spec:
   versions:
     - my-operator.v0.1.1
     - my-operator.v0.2.0
-  upgradeApproval: Automatic # or Never
+  upgradeApproval: Automatic # or None
   removalBehavior:
     operatorGroups: DeleteIfUnused
     subscriptions: Delete


### PR DESCRIPTION
`OperatorPolicy.spec.upgradeApproval`should be set to either `Automatic` or `None`.

`Never` was never a value or can mislead users who don't read through the entire readme.